### PR TITLE
Fix path for INFINITIME_DIR variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ podman run --rm -it -v ${PWD}:/sources infinisim-build
 ```
 
 By default this builds the simulator using the InfiniTime files from the submodule in your `${PWD}`.
-If you want to use a different repository, you got to mount it and pass the path to the `/sources/InfiniTime` directory:
+If you want to use a different repository, the easiest way is to mount over the default submodule location in the container at `/sources/InfiniTime`:
 ```sh
 docker run --rm -it -v ${PWD}:/sources -v ${PWD}/../InfiniTime:/sources/InfiniTime --user $(id -u):$(id -g) infinisim-build
 ```

--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ podman run --rm -it -v ${PWD}:/sources infinisim-build
 ```
 
 By default this builds the simulator using the InfiniTime files from the submodule in your `${PWD}`.
-If you want to use a different repository, you got to mount it and pass the path to the `INFINITIME_DIR` variable:
+If you want to use a different repository, you got to mount it and pass the path to the `/sources/InfiniTime` directory:
 ```sh
-docker run --rm -it -v ${PWD}:/sources -v ${PWD}/../InfiniTime:/infinitime -e INFINITIME_DIR=/infinitime  --user $(id -u):$(id -g) infinisim-build
+docker run --rm -it -v ${PWD}:/sources -v ${PWD}/../InfiniTime:/sources/InfiniTime --user $(id -u):$(id -g) infinisim-build
 ```
 
 Other CMake generation and build arguments can be passed to the `GENERATE_ARGS` and `BUILD_ARGS` variables:


### PR DESCRIPTION
The Dockerfile overhauls the Infinitime_DIR path and it seems impossible to have a default variable, because of this I suggest the docs suggest passing the `/sources/InfiniTime` as it makes it work perfectly.